### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
-sudo: false
 cache: bundler
 before_install: gem install bundler -v 1.12.5
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
we can get rid of `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration