### PR TITLE
Strip spaces around provided dsn string

### DIFF
--- a/lib/pg/dsn_parser.rb
+++ b/lib/pg/dsn_parser.rb
@@ -8,7 +8,7 @@ module PG
     end
 
     def parse(dsn)
-      scanner = StringScanner.new(dsn)
+      scanner = StringScanner.new(dsn.strip)
 
       dsn_hash = {}
 

--- a/lib/pg/dsn_parser.rb
+++ b/lib/pg/dsn_parser.rb
@@ -14,7 +14,7 @@ module PG
 
       until scanner.eos?
         # get the key by matching up to and including the (optionally) white space bordered '='
-        key = scanner.scan_until(/\s?=\s?/)
+        key = scanner.scan_until(/\s*=\s*/)
         key = key[0...-scanner.matched_size]
 
         dsn_hash[key.to_sym] = get_dsn_value(scanner)

--- a/spec/pg/dsn_parser_spec.rb
+++ b/spec/pg/dsn_parser_spec.rb
@@ -32,6 +32,11 @@ describe PG::DSNParser do
       expect(subject.parse(s)).to eq(:host => "local host")
     end
 
+    it "leading space before key" do
+      s = " host = 'local host'"
+      expect(subject.parse(s)).to eq(:host => "local host")
+    end
+
     it "spaces, quotes, quote in value" do
       s = "host = 'local\\'shost\\''"
       expect(subject.parse(s)).to eq(:host => "local'shost'")

--- a/spec/pg/dsn_parser_spec.rb
+++ b/spec/pg/dsn_parser_spec.rb
@@ -28,13 +28,13 @@ describe PG::DSNParser do
     end
 
     it "spaces, quotes, space in value" do
-      s = "host = 'local host'"
-      expect(subject.parse(s)).to eq(:host => "local host")
+      s = "password = 'pass word'"
+      expect(subject.parse(s)).to eq(:password => "pass word")
     end
 
     it "leading space before key" do
-      s = " host = 'local host'"
-      expect(subject.parse(s)).to eq(:host => "local host")
+      s = " password = 'pass word'"
+      expect(subject.parse(s)).to eq(:password => "pass word")
     end
 
     it "multiple space around equals" do
@@ -48,8 +48,8 @@ describe PG::DSNParser do
     end
 
     it "spaces, quotes, quote in value" do
-      s = "host = 'local\\'shost\\''"
-      expect(subject.parse(s)).to eq(:host => "local'shost'")
+      s = "password = 'pass\\'sword\\''"
+      expect(subject.parse(s)).to eq(:password => "pass'sword'")
     end
 
     it "full dsn quoted" do

--- a/spec/pg/dsn_parser_spec.rb
+++ b/spec/pg/dsn_parser_spec.rb
@@ -37,6 +37,16 @@ describe PG::DSNParser do
       expect(subject.parse(s)).to eq(:host => "local host")
     end
 
+    it "multiple space around equals" do
+      s = "host =  localhost"
+      expect(subject.parse(s)).to eq(:host => "localhost")
+    end
+
+    it "multiple space around equals for second value" do
+      s = "host = localhost dbname =  vmdb_test"
+      expect(subject.parse(s)).to eq(:host => "localhost", :dbname => 'vmdb_test')
+    end
+
     it "spaces, quotes, quote in value" do
       s = "host = 'local\\'shost\\''"
       expect(subject.parse(s)).to eq(:host => "local'shost'")


### PR DESCRIPTION
Before:

```
PG::DSNParser.parse(" host = 'local host'")
=> {:" host"=>"local host"}
```

After:

```
PG::DSNParser.parse(" host = 'local host'")
=> {:host=>"local host"}
```

And... multiple spaces around the equals would fail to parse:

Before:

```
PG::DSNParser.parse("host =  localhost")
=>     NoMethodError:
       undefined method `-@' for nil:NilClass
```

After:

```
PG::DSNParser.parse("host =  localhost")
=> {:host=>"localhost"}
```
