### PR TITLE
Adds Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,10 +16,11 @@ jobs:
         - '2.6'
         - '2.7'
         - '3.0'
+        - '3.1'
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Also updates the version of the checkout action.

Runs green on my fork.